### PR TITLE
ci: switch PyPI publish to trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,12 @@ jobs:
 
   publish-pypi:
     needs: build
-    if: ${{ secrets.PYPI_API_TOKEN != '' }}
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -35,5 +39,3 @@ jobs:
           path: dist
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Summary
- migrate PyPI release workflow from token-based auth to Trusted Publishing
- add environment: pypi on publish job
- add OIDC permissions (id-token: write)

## Why
Matches PyPI Trusted Publisher setup and removes long-lived API token requirement.