### PR TITLE
ci: enable dependabot auto-merge for minor and patch updates

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,28 @@
+name: Dependabot Auto Merge
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch/minor updates
+        if: |
+          startsWith(steps.metadata.outputs.update-type, 'version-update:semver-patch') ||
+          startsWith(steps.metadata.outputs.update-type, 'version-update:semver-minor')
+        run: gh pr merge --auto --squash "${{ github.event.pull_request.html_url }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- add Dependabot auto-merge workflow
- auto-enables merge only for semver patch/minor updates
- leaves major updates for manual review

## Safety
- workflow runs only for dependabot[bot]
- uses PR checks and GitHub auto-merge